### PR TITLE
Refactor build scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+*.o
+*.bin
+*.model
+*.dSYM/
+
+ffm-predict
+ffm-train
+
+build/
+data/
+model/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.12)
+
+project(libffm CXX)
+
+OPTION(USE_OPENMP "Enable OpenMP" ON)
+OPTION(USE_SSE "Enable SSE acceleration" ON)
+
+set(CMAKE_C_STANDARD 11)
+SET(CMAKE_CXX_COMPILER g++)
+set(CMAKE_VERBOSE_MAKEFILE ON)
+set(CMAKE_CXX_FLAGS "-Wall -O3 -std=c++0x -march=native")
+
+if (USE_SSE)
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSESSE")
+endif(USE_SSE)
+
+if(USE_OPENMP)
+    find_package(OpenMP REQUIRED)
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+else()
+    # Ignore unknown #pragma warning
+    if((CMAKE_CXX_COMPILER_ID STREQUAL "Clang") OR (CMAKE_CXX_COMPILER_ID STREQUAL "GNU"))
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas")
+    endif()
+endif(USE_OPENMP)
+
+add_library(ffm SHARED ffm.cpp timer.cpp)
+add_executable(ffm-train ffm-train.cpp ffm.cpp timer.cpp)
+add_executable(ffm-predict ffm-predict.cpp ffm.cpp timer.cpp)

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,23 @@
 CXX = g++
 CXXFLAGS = -Wall -O3 -std=c++0x -march=native
 
-# comment the following flags if you do not want to SSE instructions
-DFLAG += -DUSESSE
+ifneq ($(USESSE), OFF)
+	DFLAG += -DUSESSE
+endif
 
-# comment the following flags if you do not want to use OpenMP
-DFLAG += -DUSEOMP
-CXXFLAGS += -fopenmp
+ifneq ($(USEOMP), OFF)
+	DFLAG += -DUSEOMP
+	OMP_CXXFLAGS ?= -fopenmp
+	CXXFLAGS += $(OMP_CXXFLAGS)
+endif
 
 all: ffm-train ffm-predict
 
 ffm-train: ffm-train.cpp ffm.o timer.o
-	$(CXX) $(CXXFLAGS) $(DFLAG) -o $@ $^
+	$(CXX) $(CXXFLAGS) $(DFLAG) $(OMP_LDFLAGS) -o $@ $^
 
 ffm-predict: ffm-predict.cpp ffm.o timer.o
-	$(CXX) $(CXXFLAGS) $(DFLAG) -o $@ $^
+	$(CXX) $(CXXFLAGS) $(DFLAG) $(OMP_LDFLAGS) -o $@ $^
 
 ffm.o: ffm.cpp ffm.h timer.o
 	$(CXX) $(CXXFLAGS) $(DFLAG) -c -o $@ $<

--- a/README
+++ b/README
@@ -240,6 +240,21 @@ please run make with following arguments:
 
     make USESSE=OFF
 
+Building macOS Binaries
+=======================
+
+Apple clang (use libomp)
+
+    brew install libomp
+    make OMP_CXXFLAGS="-Xpreprocessor -fopenmp -I$(brew --prefix libomp)/include" OMP_LDFLAGS="-L$(brew --prefix libomp)/lib -lomp"
+
+Using gcc (installed by homebrew)
+
+    brew install gcc
+    make CXX="g++-8"
+
+Note: replace "8" with version of gcc installed on your machine
+
 
 Building Windows Binaries
 =========================

--- a/README
+++ b/README
@@ -229,19 +229,16 @@ OpenMP and SSE
 ==============
 
 We use OpenMP to do parallelization. If OpenMP is not available on your
-platform, then please comment out the following lines in Makefile.
+platform, then please run make with following arguments.
 
-    DFLAG += -DUSEOMP
-    CXXFLAGS += -fopenmp
+    make USEOMP=OFF
 
 Note: Please run `make clean all' if these flags are changed.
 
-We use SSE instructions to perform fast computation. If you do not want to use it, comment out the following line:
+We use SSE instructions to perform fast computation. If you do not want to use it,
+please run make with following arguments:
 
-    DFLAG += -DUSESSE
-
-Then, run `make clean all'
-
+    make USESSE=OFF
 
 
 Building Windows Binaries


### PR DESCRIPTION
## Changes

* [x] Add CMakeLists.txt for CLion users.
* [x] Update Makefile
* [x] Add description to build macOS binaries.
* [x] Update .gitignore

## How to build on macOS

### Apple clang (use libomp)

```console
$ brew install libomp
$ make OMP_CXXFLAGS="-Xpreprocessor -fopenmp -I$(brew --prefix libomp)/include" OMP_LDFLAGS="-L$(brew --prefix libomp)/lib -lomp"
```

or cmake

```
$ brew install libomp
$ mkdir build
$ cd build
$ cmake \
  -DOpenMP_CXX_FLAGS="-Xpreprocessor -fopenmp -I$(brew --prefix libomp)/include" \
  -DOpenMP_CXX_LIB_NAMES="omp" \
  -DOpenMP_omp_LIBRARY=$(brew --prefix libomp)/lib/libomp.dylib \
  ..
$ make
```

See https://cmake.org/cmake/help/latest/module/FindOpenMP.html

### Using gcc (installed by homebrew)

```console
$ brew install gcc
$ make CXX="g++-8"
```

or cmake

```
$ brew install gcc
$ export CXX=g++-8
$ mkdir build && cd build
$ cmake ..
$ make
```

### Disable OpenMP

```diff
$ make USEOMP=OFF
```

or cmake

```
$ mkdir build && cd build
$ cmake -DUSE_OPENMP=OFF ..
$ make
```
 