### PR TITLE
Multiply importance weight plan A

### DIFF
--- a/ffm.cpp
+++ b/ffm.cpp
@@ -41,6 +41,7 @@ inline ffm_float wTx(ffm_node *begin, ffm_node *end, ffm_float r,
   __m128 XMMlambda = _mm_set1_ps(lambda);
 
   __m128 XMMt = _mm_setzero_ps();
+  __m128 XMMiw = _mm_set1_ps(iw);
 
   for (ffm_node *N1 = begin; N1 != end; N1++) {
     ffm_int j1 = N1->j;
@@ -83,10 +84,10 @@ inline ffm_float wTx(ffm_node *begin, ffm_node *end, ffm_float r,
 
           XMMw1 = _mm_sub_ps(
               XMMw1,
-              _mm_mul_ps(XMMeta, _mm_mul_ps(_mm_rsqrt_ps(XMMwg1), XMMg1)));
+              _mm_mul_ps(XMMeta, _mm_mul_ps(XMMiw, _mm_mul_ps(_mm_rsqrt_ps(XMMwg1), XMMg1))));
           XMMw2 = _mm_sub_ps(
               XMMw2,
-              _mm_mul_ps(XMMeta, _mm_mul_ps(_mm_rsqrt_ps(XMMwg2), XMMg2)));
+              _mm_mul_ps(XMMeta, _mm_mul_ps(XMMiw, _mm_mul_ps(_mm_rsqrt_ps(XMMwg2), XMMg2))));
 
           _mm_store_ps(w1 + d, XMMw1);
           _mm_store_ps(w2 + d, XMMw2);


### PR DESCRIPTION
Multiply the importance weight to the equation (9) and (10) in the paper.
https://www.csie.ntu.edu.tw/~cjlin/papers/ffm.pdf

```console
$ make clean && make USEOMP=OFF
$ ./ffm-train -p ./data/iw_sample/valid_obs.ffm -W ./data/iw_sample/fsiw.txt -f ./model/prod-cvr2.model --auto-stop ./data/iw_sample/train_obs.ffm
rm -f ffm-train ffm-predict ffm.o
g++ -Wall -O3 -std=c++0x -march=native -DUSESSE -c -o ffm.o ffm.cpp
g++ -Wall -O3 -std=c++0x -march=native -o ffm-train ffm-train.cpp ffm.o
g++ -Wall -O3 -std=c++0x -march=native -o ffm-predict ffm-predict.cpp ffm.o
iter   tr_logloss   va_logloss
   1      0.31138      0.12997
   2      0.30481      0.11969
   3      0.30212      0.12137
Auto-stop. Use model at 2th iteration.
cannot parse argument
```

https://github.com/ycjuan/libffm/blob/94eb4c8fd8c63b5b292512fa8e952e1ecc83c1b2/ffm.cpp#L225-L226