### PR TITLE
Multiply importance weight plan B

### DIFF
--- a/ffm.cpp
+++ b/ffm.cpp
@@ -41,6 +41,7 @@ inline ffm_float wTx(ffm_node *begin, ffm_node *end, ffm_float r,
   __m128 XMMlambda = _mm_set1_ps(lambda);
 
   __m128 XMMt = _mm_setzero_ps();
+  __m128 XMMiw = _mm_set1_ps(iw);
 
   for (ffm_node *N1 = begin; N1 != end; N1++) {
     ffm_int j1 = N1->j;
@@ -73,10 +74,12 @@ inline ffm_float wTx(ffm_node *begin, ffm_node *end, ffm_float r,
           __m128 XMMwg1 = _mm_load_ps(wg1 + d);
           __m128 XMMwg2 = _mm_load_ps(wg2 + d);
 
-          __m128 XMMg1 = _mm_add_ps(_mm_mul_ps(XMMlambda, XMMw1),
-                                    _mm_mul_ps(XMMkappav, XMMw2));
-          __m128 XMMg2 = _mm_add_ps(_mm_mul_ps(XMMlambda, XMMw2),
-                                    _mm_mul_ps(XMMkappav, XMMw1));
+          __m128 XMMg1 = _mm_mul_ps(_mm_add_ps(_mm_mul_ps(XMMlambda, XMMw1),
+                                               _mm_mul_ps(XMMkappav, XMMw2)),
+                                    XMMiw);
+          __m128 XMMg2 = _mm_mul_ps(_mm_add_ps(_mm_mul_ps(XMMlambda, XMMw2),
+                                               _mm_mul_ps(XMMkappav, XMMw1)),
+                                    XMMiw);
 
           XMMwg1 = _mm_add_ps(XMMwg1, _mm_mul_ps(XMMg1, XMMg1));
           XMMwg2 = _mm_add_ps(XMMwg2, _mm_mul_ps(XMMg2, XMMg2));


### PR DESCRIPTION
Multiply the importance weight to the equation (5) and (6) in the paper.
https://www.csie.ntu.edu.tw/~cjlin/papers/ffm.pdf

```console
$ make clean && make USEOMP=OFF
$ ./ffm-train -p ./data/iw_sample/valid_obs.ffm -W ./data/iw_sample/fsiw.txt -f ./model/prod-cvr2.model --auto-stop ./data/iw_sample/train_obs.ffm
iter   tr_logloss   va_logloss
   1      0.31121      0.13124
   2      0.30463      0.12108
   3      0.30204      0.12171
Auto-stop. Use model at 2th iteration.
```

https://github.com/ycjuan/libffm/blob/94eb4c8fd8c63b5b292512fa8e952e1ecc83c1b2/ffm.cpp#L212
