### PR TITLE
Add threshold count for auto-stopping

### DIFF
--- a/README
+++ b/README
@@ -139,12 +139,17 @@ Command Line Usage
     -r <eta>: set learning rate (default 0.2)
     -s <nr_threads>: set number of threads (default 1)
     -p <path>: set path to the validation set
+    -f <path>: set path for production model file
+    -m <prefix>: set key prefix for production model
+    -W <path>: set path of importance weights file for training set
+    -WV <path>: set path of importance weights file for validation set
     -v <fold>: set the number of folds for cross-validation
     --quiet: quiet model (no output)
     --no-norm: disable instance-wise normalization
     --no-rand: disable random update
-    --on-disk: perform on-disk training (a temporary file <training_set_file>.bin will be generated)
+    <training_set_file>.bin will be generated)
     --auto-stop: stop at the iteration that achieves the best validation loss (must be used with -p)
+    --auto-stop-threshold: set the threshold count for stop at the iteration that achieves the best validation loss (must be used with --auto-stop)
 
     By default we do instance-wise normalization. That is, we normalize the 2-norm of each instance to 1. You can use
     `--no-norm' to disable this function.

--- a/ffm-train.cpp
+++ b/ffm-train.cpp
@@ -32,7 +32,10 @@ string train_help() {
                 "--no-rand: disable random update\n"
                 "<training_set_file>.bin will be generated)\n"
                 "--auto-stop: stop at the iteration that achieves the best "
-                "validation loss (must be used with -p)\n");
+                "validation loss (must be used with -p)\n"
+                "--auto-stop-threshold: set the threshold count for stop at the iteration"
+                " that achieves the best validation loss (must be used with --auto-stop)\n"
+                );
 }
 
 struct Option {
@@ -144,6 +147,11 @@ Option parse_option(int argc, char **argv) {
       opt.param.random = false;
     } else if (args[i].compare("--auto-stop") == 0) {
       opt.param.auto_stop = true;
+    } else if (args[i].compare("--auto-stop-threshold") == 0) {
+      if (i == argc - 1)
+        throw invalid_argument("need to specify weights file path after -W");
+      i++;
+      opt.param.auto_stop_threshold = atoi(args[i].c_str());
     } else {
       break;
     }

--- a/ffm.cpp
+++ b/ffm.cpp
@@ -29,7 +29,6 @@ ffm_int const kALIGNByte = 16;
 ffm_int const kALIGN = kALIGNByte / sizeof(ffm_float);
 ffm_int const kCHUNK_SIZE = 10000000;
 ffm_int const kMaxLineSize = 100000;
-ffm_int const AUTO_STOP_THRESHOLD = 3;
 
 inline ffm_float wTx(ffm_node *begin, ffm_node *end, ffm_float r,
                      ffm_model &model,
@@ -233,7 +232,7 @@ shared_ptr<ffm_model> train(ffm_problem *tr, vector<ffm_int> &order,
     prev_W.assign(w_size, 0);
   ffm_double best_va_loss = numeric_limits<ffm_double>::max();
   ffm_int best_iteration = 0;
-  ffm_int loss_worse_counter = AUTO_STOP_THRESHOLD;
+  ffm_int loss_worse_counter = param.auto_stop_threshold;
 
   if (!param.quiet) {
     if (param.auto_stop && (va == nullptr || va->l == 0))
@@ -338,7 +337,7 @@ shared_ptr<ffm_model> train(ffm_problem *tr, vector<ffm_int> &order,
               memcpy(prev_W.data(), model->W, w_size * sizeof(ffm_float));
             }
           } else {
-            loss_worse_counter = AUTO_STOP_THRESHOLD;  // reset the counter
+            loss_worse_counter = param.auto_stop_threshold;  // reset the counter
             memcpy(prev_W.data(), model->W, w_size * sizeof(ffm_float));
             best_va_loss = va_loss;
             best_iteration = iter;

--- a/ffm.h
+++ b/ffm.h
@@ -47,6 +47,7 @@ struct ffm_parameter {
   ffm_int nr_iters;
   ffm_int k;
   ffm_int nr_threads;
+  ffm_int auto_stop_threshold;
   bool quiet;
   bool normalization;
   bool random;


### PR DESCRIPTION
```
$ make clean && make USEOMP=OFF
rm -f ffm-train ffm-predict ffm.o
g++ -Wall -O3 -std=c++0x -march=native -DUSESSE -c -o ffm.o ffm.cpp
g++ -Wall -O3 -std=c++0x -march=native -o ffm-train ffm-train.cpp ffm.o
g++ -Wall -O3 -std=c++0x -march=native -o ffm-predict ffm-predict.cpp ffm.o
a14737: ~/src/github.com/ycjuan/libffm [auto-stop-loss-counter]
$ ./ffm-train -p ./data/iw_sample/valid_obs.ffm -W ./data/iw_sample/fsiw.txt -f ./model/prod-cvr2.model --auto-stop ./data/iw_sample/train_obs.ffm
iter   tr_logloss   va_logloss
   1      0.30622      0.09509
   2      0.30004      0.08485
   3      0.29771      0.08453
   4      0.29563      0.09146
   5      0.29354      0.09543
   6      0.29143      0.09068
Auto-stop. Use model at 3th iteration.
```