### PR TITLE
Add --json-meta option in ffm-train

### DIFF
--- a/README
+++ b/README
@@ -146,8 +146,8 @@ Command Line Usage
     -v <fold>: set the number of folds for cross-validation
     --quiet: quiet model (no output)
     --no-norm: disable instance-wise normalization
-    --no-rand: disable random update
-    <training_set_file>.bin will be generated)
+    --no-rand: disable random update <training_set_file>.bin will be generated)
+    --json-meta: generate a meta file if sets json file path.
     --auto-stop: stop at the iteration that achieves the best validation loss (must be used with -p)
     --auto-stop-threshold: set the threshold count for stop at the iteration that achieves the best validation loss (must be used with --auto-stop)
 

--- a/ffm-train.cpp
+++ b/ffm-train.cpp
@@ -30,7 +30,7 @@ string train_help() {
       "-v <fold>: set the number of folds for cross-validation\n"
       "--quiet: quiet model (no output)\n"
       "--no-norm: disable instance-wise normalization\n"
-      "--no-rand: disable random update\n"
+      "--no-rand: disable random update "
       "<training_set_file>.bin will be generated)\n"
       "--json-meta: generate a meta file if sets json file path.\n"
       "--auto-stop: stop at the iteration that achieves the best "

--- a/ffm-train.cpp
+++ b/ffm-train.cpp
@@ -32,6 +32,7 @@ string train_help() {
       "--no-norm: disable instance-wise normalization\n"
       "--no-rand: disable random update\n"
       "<training_set_file>.bin will be generated)\n"
+      "--json-meta: generate a meta file if sets json file path.\n"
       "--auto-stop: stop at the iteration that achieves the best "
       "validation loss (must be used with -p)\n"
       "--auto-stop-threshold: set the threshold count for stop at the iteration"
@@ -148,6 +149,13 @@ Option parse_option(int argc, char **argv) {
       opt.param.random = false;
     } else if (args[i].compare("--auto-stop") == 0) {
       opt.param.auto_stop = true;
+    } else if (args[i].compare("--json-meta") == 0) {
+      if (i == argc - 1)
+        throw invalid_argument("need to specify weights file path after -W");
+      i++;
+      char *json_meta_path = new char[args[i].length() + 1];
+      strcpy(json_meta_path, args[i].c_str());
+      opt.param.json_meta_path = json_meta_path;
     } else if (args[i].compare("--auto-stop-threshold") == 0) {
       if (i == argc - 1)
         throw invalid_argument("need to specify weights file path after -W");

--- a/ffm.cpp
+++ b/ffm.cpp
@@ -260,7 +260,7 @@ shared_ptr<ffm_model> train(ffm_problem *tr, vector<ffm_int> &order,
       ffm_float y = tr->Y[i];
       ffm_float iw = 1.0;
       if (iws != nullptr) {
-          iw = iws->W[i];
+        iw = iws->W[i];
       }
 
       ffm_node *begin = &tr->X[tr->P[i]];

--- a/ffm.cpp
+++ b/ffm.cpp
@@ -348,6 +348,15 @@ shared_ptr<ffm_model> train(ffm_problem *tr, vector<ffm_int> &order,
     }
   }
 
+  // generate json meta file.
+  if (param.json_meta_path != nullptr) {
+    ofstream f_out(param.json_meta_path);
+    if (f_out.is_open()) {
+      f_out << "{\"best_iteration\": " << best_iteration << "}\n" << flush;
+      f_out.close();
+    }
+  }
+
   shrink_model(*model, param.k);
 
 #if defined USEOMP
@@ -580,10 +589,12 @@ ffm_parameter ffm_get_default_param() {
   param.nr_iters = 15;
   param.k = 4;
   param.nr_threads = 1;
+  param.auto_stop_threshold = -1;
   param.quiet = false;
   param.normalization = true;
   param.random = true;
   param.auto_stop = false;
+  param.json_meta_path = nullptr;
 
   return param;
 }

--- a/ffm.h
+++ b/ffm.h
@@ -48,6 +48,7 @@ struct ffm_parameter {
   ffm_int k;
   ffm_int nr_threads;
   ffm_int auto_stop_threshold;
+  char* json_meta_path;
   bool quiet;
   bool normalization;
   bool random;

--- a/ffm.h
+++ b/ffm.h
@@ -48,7 +48,7 @@ struct ffm_parameter {
   ffm_int k;
   ffm_int nr_threads;
   ffm_int auto_stop_threshold;
-  char* json_meta_path;
+  char *json_meta_path;
   bool quiet;
   bool normalization;
   bool random;


### PR DESCRIPTION
Export the meta json file which contains best iteration count if `--json-meta <filepath>` sets something.

```
$ ./ffm-train -p ./data/iw_sample/valid_obs.ffm -f ./model/prod-cvr2.model --auto-stop --json-meta ./model/ffm_train_meta.json ./data/iw_sample/train_obs.ffm
iter   tr_logloss   va_logloss
   1      0.30622      0.09509
   2      0.30004      0.08485
   3      0.29771      0.08453
   4      0.29563      0.09146
Auto-stop. Use model at 3th iteration.

$ cat ./model/ffm_train_meta.json 
{"best_iteration": 3}

$ ./ffm-train -p ./data/iw_sample/valid_obs.ffm -f ./model/prod-cvr2.model -t `cat ./model/ffm_train_meta.json | jq ".best_iteration"` ./data/iw_sample/train_obs.ffm
iter   tr_logloss   va_logloss
   1      0.30622      0.09509
   2      0.30004      0.08485
   3      0.29771      0.08453
```