### PR TITLE
Add Dockerfile to exec valgrind

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:18.04
+MAINTAINER Masashi Shibata <contact@c-bata.link>
+
+RUN apt-get update && \
+    apt-get install -y build-essential valgrind cmake && \
+    rm -rf /var/lib/apt/lists/*
+
+
+ADD ./Makefile /usr/src/Makefile
+ADD ./*.cpp /usr/src/
+ADD ./*.h /usr/src/
+
+WORKDIR /usr/src
+RUN make USEOMP=OFF
+
+VOLUME /usr/src/data
+CMD ["bash"]

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,12 @@ endif
 
 all: ffm-train ffm-predict
 
+valgrind:
+	docker build -t cyberagent/libffm .
+	docker run -it --rm \
+		-v `PWD`/data:/usr/src/data \
+		bash
+
 ffm-train: ffm-train.cpp ffm.o
 	$(CXX) $(CXXFLAGS) -o $@ $^
 


### PR DESCRIPTION
```
$ make valgrind
> # run valgrind in a docker container.
> # move callgrind.out.27 to data directory
> quit
$ brew install qcachegrind
$ qcachegrind ./data/callgrind.out.27 
```

![スクリーンショット 2019-08-27 18 02 30](https://user-images.githubusercontent.com/5564044/63757591-516ab080-c8f5-11e9-8b96-4e3af9af6851.png)
