### PR TITLE
Fix exit status when unset production json model

### DIFF
--- a/ffm-train.cpp
+++ b/ffm-train.cpp
@@ -250,7 +250,7 @@ int train(Option opt) {
     status = ffm_save_model(model, opt.model_path.c_str());
 
     // Production model
-    if (opt.production_model_path.c_str() != nullptr)
+    if (!opt.production_model_path.empty())
       status = ffm_save_production_model(
           model, opt.production_model_path.c_str(), opt.key_prefix.c_str());
 


### PR DESCRIPTION
Currently `ffm-train` exited with 1 when unset `-f` option.

```
$ ./ffm-train -p ./data/iw_sample/valid_obs.ffm -W ./data/iw_sample/fsiw.txt -f ./model/prod-cvr2.model --auto-stop ./data/iw_sample/train_obs.ffm 
iter   tr_logloss   va_logloss
   1      0.30622      0.09509
   2      0.30004      0.08485
   3      0.29771      0.08453
   4      0.29563      0.09146
Auto-stop. Use model at 3th iteration.
$ echo $?
0
```

```
$ ./ffm-train -p ./data/iw_sample/valid_obs.ffm -W ./data/iw_sample/fsiw.txt --auto-stop ./data/iw_sample/train_obs.ffm 
iter   tr_logloss   va_logloss
   1      0.30622      0.09509
   2      0.30004      0.08485
   3      0.29771      0.08453
   4      0.29563      0.09146
Auto-stop. Use model at 3th iteration.
$ echo $?
1
```