### PR TITLE
Dump model with FFM format

### DIFF
--- a/examples/train_from_file.py
+++ b/examples/train_from_file.py
@@ -20,7 +20,7 @@ def main():
     print("Best iteration:", model.best_iteration)
 
     with open("./model/prod-cvr.model", 'w') as f:
-        model.dump_model(f, key_prefix="key")
+        model.dump_model(f)
 
 
 if __name__ == '__main__':

--- a/examples/train_from_file.py
+++ b/examples/train_from_file.py
@@ -19,9 +19,8 @@ def main():
     )
     print("Best iteration:", model.best_iteration)
 
-    # Dump FFM weights in ffm-train's "-m" option format.
     with open("./model/prod-cvr.model", 'w') as f:
-        model.dump_libffm_weights(f, key_prefix="key")
+        model.dump_model(f, key_prefix="key")
 
 
 if __name__ == '__main__':

--- a/examples/train_simple.py
+++ b/examples/train_simple.py
@@ -15,9 +15,8 @@ def main():
     )
     print("Best iteration:", model.best_iteration)
 
-    # Dump FFM weights in ffm-train's "-m" option format.
     with open("./model/prod-cvr.model", 'w') as f:
-        model.dump_libffm_weights(f)
+        model.dump_model(f)
 
 
 if __name__ == '__main__':

--- a/ffm/__init__.py
+++ b/ffm/__init__.py
@@ -110,7 +110,9 @@ def train(
         normalization=normalization,
         random=random,
     )
-    return Model(weights=weights, best_iteration=best_iteration, normalization=normalization)
+    return Model(
+        weights=weights, best_iteration=best_iteration, normalization=normalization
+    )
 
 
 def read_importance_weights(fp: IO) -> List[float]:

--- a/ffm/cli.py
+++ b/ffm/cli.py
@@ -7,7 +7,13 @@ from ffm import Dataset, train
 def ffm_train() -> None:
     parser = argparse.ArgumentParser(description="LibFFM CLI")
     parser.add_argument("tr_path", help="File path to training set", type=str)
-    parser.add_argument("model_path", help="File path to training set", nargs='?', type=str, default=None)
+    parser.add_argument(
+        "model_path",
+        help="File path to training set",
+        nargs="?",
+        type=str,
+        default=None,
+    )
     parser.add_argument(
         "-p", help="Set path to the validation set", type=str, default=""
     )

--- a/ffm/cli.py
+++ b/ffm/cli.py
@@ -7,6 +7,7 @@ from ffm import Dataset, train
 def ffm_train() -> None:
     parser = argparse.ArgumentParser(description="LibFFM CLI")
     parser.add_argument("tr_path", help="File path to training set", type=str)
+    parser.add_argument("model_path", help="File path to training set", nargs='?', type=str, default=None)
     parser.add_argument(
         "-p", help="Set path to the validation set", type=str, default=""
     )
@@ -71,6 +72,10 @@ def ffm_train() -> None:
     if args.f:
         with open(args.f, "w") as f:
             model.dump_libffm_weights(f, key_prefix=args.m)
+
+    if args.model_path:
+        with open(args.model_path, "w") as f:
+            model.dump_model(f)
 
     if args.json_meta:
         with open(args.json_meta, "w") as f:

--- a/ffm/libffm.pyx
+++ b/ffm/libffm.pyx
@@ -152,6 +152,7 @@ cdef object _train(
         raise MemoryError("Invalid model pointer")
 
     best_iteration = model_ptr.best_iteration
+    normalization = True if model_ptr.normalization else False
 
     cdef:
         cnp.npy_intp shape[3]
@@ -165,7 +166,7 @@ cdef object _train(
     f._data = <void*> model_ptr.W
     cnp.set_array_base(arr, f)
     free(model_ptr)
-    return arr, best_iteration
+    return arr, best_iteration, normalization
 
 
 def train(
@@ -218,10 +219,10 @@ def train(
         iwv_ptr = NULL
 
     try:
-        weights, best_iteration = _train(tr_ptr, va_ptr, iw_ptr, iwv_ptr, param)
+        weights, best_iteration, normalization = _train(tr_ptr, va_ptr, iw_ptr, iwv_ptr, param)
     finally:
         free_ffm_prob(tr_ptr)
         free_ffm_prob(va_ptr)
         free_ffm_iw(iw_ptr)
         free_ffm_iw(iwv_ptr)
-    return weights, best_iteration
+    return weights, best_iteration, normalization

--- a/regression_test.sh
+++ b/regression_test.sh
@@ -14,4 +14,9 @@ pyffm-train -p ./bigdata.te.txt -W ./bigdata.iw.txt -f ./model/dummy-2.model -m 
 
 diff ./model/dummy-1.model ./model/dummy-2.model
 
+./ffm-train -p ./bigdata.te.txt -W ./bigdata.iw.txt -m key --auto-stop --auto-stop-threshold 3 ./bigdata.tr.txt ./model/dummy-3.model
+pyffm-train -p ./bigdata.te.txt -W ./bigdata.iw.txt -m key --auto-stop --auto-stop-threshold 3 ./bigdata.tr.txt ./model/dummy-4.model
+
+diff ./model/dummy-3.model ./model/dummy-4.model
+
 echo "ok"


### PR DESCRIPTION
Pythonバインディングにおいて、LIBFFMがdumpするモデルと同じ形式の出力に対応しました。使い方は次のようになります。

```python
import ffm


def main():
    # Prepare the data. (field, index, value) format
    X = [[(1, 2, 1), (2, 3, 1), (3, 5, 1)],
         [(1, 0, 1), (2, 3, 1), (3, 7, 1)],
         [(1, 1, 1), (2, 3, 1), (3, 7, 1), (3, 9, 1)], ]
    y = [1, 1, 0]
    train_data = ffm.Dataset(X, y)

    model = ffm.train(
        train_data,
        quiet=False
    )
    print("Best iteration:", model.best_iteration)

    with open("./model/prod-cvr.model", 'w') as f:
        model.dump_model(f)


if __name__ == '__main__':
    main()
```

pyffm-trainコマンドにも実装し、次のコマンドの出力が完全に一致 (モデルファイルの形式が完全に同じ) ことを確認しています。

```bash
./ffm-train -p ./bigdata.te.txt -W ./bigdata.iw.txt --auto-stop --auto-stop-threshold 3 ./bigdata.tr.txt ./model/dummy-1.model
pyffm-train -p ./bigdata.te.txt -W ./bigdata.iw.txt --auto-stop --auto-stop-threshold 3 ./bigdata.tr.txt ./model/dummy-2.model

diff ./model/dummy-1.model ./model/dummy-2.model
```