### PR TITLE
Implement `Model.predict()` method and `pyffm-predict` command.

### DIFF
--- a/ffm/__init__.py
+++ b/ffm/__init__.py
@@ -2,6 +2,7 @@ import warnings
 import numpy as np
 from typing import Optional, Sequence, List, Tuple, IO
 from ffm.libffm import train as libffm_train
+from ffm.libffm import predict as ffm_predict
 
 __all__ = ["Dataset", "Model", "train"]
 
@@ -58,6 +59,11 @@ class Model:
                 # Put space before break line to keep LIBFFM's output compatibility.
                 fp.write(f"w{i},{j} {w} \n")
 
+    def predict(
+        self, data: Sequence[Tuple[int, int, float]]
+    ) -> float:
+        return ffm_predict(self.weights, data, self.normalization)
+
     def dump_libffm_weights(self, fp: IO, key_prefix: str = "") -> None:
         """Dump weights of FFM model like ffm-train's "-m" option"""
         warnings.warn(
@@ -76,6 +82,11 @@ class Model:
             key = f"{key_prefix}_{i}" if key_prefix else str(i)
             value_json = '{"key":"%s","value":{%s}}' % (key, ",".join(items))
             fp.write(value_json + "\n")
+
+    @classmethod
+    def read_ffm_model(cls, model_path: str) -> "Model":
+        with open(model_path) as f:
+            return read_ffm_model(f)
 
 
 def train(

--- a/ffm/__init__.py
+++ b/ffm/__init__.py
@@ -1,3 +1,4 @@
+import warnings
 import numpy as np
 from typing import Optional, Sequence, List, Tuple, IO
 from ffm.libffm import train as libffm_train
@@ -59,6 +60,11 @@ class Model:
 
     def dump_libffm_weights(self, fp: IO, key_prefix: str = "") -> None:
         """Dump weights of FFM model like ffm-train's "-m" option"""
+        warnings.warn(
+            "dump_libffm_weights() is deprecated because it's no longer used.",
+            category=DeprecationWarning,
+        )
+
         assert len(self.weights.shape) == 3
         float_fmt = "{:.6g}"  # This is the same format with ffm-train command.
 
@@ -158,3 +164,35 @@ def read_ffm_data(
         data.append(features)
     assert len(data) == len(labels), "data and labels must be the same length"
     return data, labels
+
+
+def read_ffm_model(fp: IO) -> Model:
+    """Read model_file and return Model object."""
+
+    def _get_value(key: str) -> str:
+        line = fp.readline()
+        if not line.startswith(key):
+            return _get_value(key)
+
+        value = line.split(" ")[1].rstrip()
+        return value
+
+    n, m, k = int(_get_value("n")), int(_get_value("m")), int(_get_value("k"))
+    normalization = _get_value("normalization") == "1"
+
+    weights = np.empty(shape=(n, m, k), dtype=np.float32)
+    for line in fp:
+        if not line.startswith("w"):
+            continue
+        columns = line.rstrip().split(" ")
+        assert len(columns) >= 2
+
+        # e.g. columns[0] == "w1,2" -> i_and_j == ["1", "2"]
+        i_and_j = columns[0][1:].split(",")
+        assert len(i_and_j) == 2
+        i, j = int(i_and_j[0]), int(i_and_j[1])
+
+        for k, col in enumerate(columns[1:]):
+            weights[i, j, k] = float(col)
+
+    return Model(weights, -1, normalization)

--- a/ffm/cli.py
+++ b/ffm/cli.py
@@ -108,7 +108,7 @@ def ffm_predict() -> None:
             y = 1.0 if float(label) > 0 else -1.0
             pred_y = model.predict(x)
             loss -= math.log(pred_y) if y == 1 else math.log(1 - pred_y)
-            f.write(f"{int(y)},{pred_y}\n")
+            f.write(f"{int(y)},{'{:.6g}'.format(pred_y)}\n")
 
         loss /= len(test_data.labels)
         print(f"logloss = {loss}")

--- a/ffm/cli.py
+++ b/ffm/cli.py
@@ -1,11 +1,12 @@
 import argparse
 import json
+import math
 
-from ffm import Dataset, train
+from ffm import Dataset, train, Model
 
 
 def ffm_train() -> None:
-    parser = argparse.ArgumentParser(description="LibFFM CLI")
+    parser = argparse.ArgumentParser(description="LibFFM CLI for train")
     parser.add_argument("tr_path", help="File path to training set", type=str)
     parser.add_argument(
         "model_path",
@@ -88,5 +89,26 @@ def ffm_train() -> None:
             json.dump({"best_iteration": model.best_iteration}, f)
 
 
-if __name__ == "__main__":
-    ffm_train()
+def ffm_predict() -> None:
+    parser = argparse.ArgumentParser(description="LibFFM CLI for predict")
+    parser.add_argument("test_path", help="File path to test set", type=str)
+    parser.add_argument("model_path", help="File path to a trained FFM model", type=str)
+    parser.add_argument(
+        "output_path", help="File path for prediction results", type=str
+    )
+    parser.add_argument("--quiet", "-q", help="quiet", action="store_true")
+    args = parser.parse_args()
+
+    test_data = Dataset.read_ffm_data(args.test_path)
+    model = Model.read_ffm_model(args.model_path)
+
+    loss = 0.0
+    with open(args.output_path, "w") as f:
+        for x, label in zip(test_data.data, test_data.labels):
+            y = 1.0 if float(label) > 0 else -1.0
+            pred_y = model.predict(x)
+            loss -= math.log(pred_y) if y == 1 else math.log(1 - pred_y)
+            f.write(f"{int(y)},{pred_y}\n")
+
+        loss /= len(test_data.labels)
+        print(f"logloss = {loss}")

--- a/ffm/libffm.pyx
+++ b/ffm/libffm.pyx
@@ -1,6 +1,7 @@
 # cython: language_level=3
 from cpython.mem cimport PyMem_Malloc, PyMem_Free
 from libc.stdlib cimport free
+import math
 cimport numpy as cnp
 
 cnp.import_array()
@@ -226,3 +227,41 @@ def train(
         free_ffm_iw(iw_ptr)
         free_ffm_iw(iwv_ptr)
     return weights, best_iteration, normalization
+
+
+def predict(float[:,:,:] weights, x, normalization):
+    cdef:
+        float r, t = 0, v, v1, v2
+        float[:, :] w1, w2
+        int n, m, k, j1, j2, f1, f2
+
+    if not normalization:
+        r = 1
+    else:
+        r = 0
+        for node in x:
+            r += node[2] * node[2]
+        r = 1 / r
+
+    n = weights.shape[0]
+    m = weights.shape[1]
+    k = weights.shape[2]
+    for node1 in x:
+        f1 = node1[0]
+        j1 = node1[1]
+        v1 = node1[2]
+        if j1 >= n or f1 >= m:
+            continue
+
+        assert len(x) > 2, "it must contain two or more ffm_nodes"
+        for node2 in x[1:]:
+            f2 = node2[0]
+            j2 = node2[1]
+            v2 = node2[2]
+            if j2 >= n or f2 >= m:
+                continue
+
+            v = v1 * v2 * r
+            for d in range(k):
+                t += weights[j1, f2, d] * weights[j2, f1, d] * v
+    return 1 / (1 + math.exp(-t))

--- a/ffm/libffm.pyx
+++ b/ffm/libffm.pyx
@@ -233,7 +233,9 @@ def predict(float[:,:,:] weights, x, normalization):
     cdef:
         float r, t = 0, v, v1, v2
         float[:, :] w1, w2
-        int n, m, k, j1, j2, f1, f2
+        int n, m, k, j1, j2, f1, f2, d
+
+    assert len(x) > 2, "it must contain two or more ffm_nodes"
 
     if not normalization:
         r = 1
@@ -246,15 +248,15 @@ def predict(float[:,:,:] weights, x, normalization):
     n = weights.shape[0]
     m = weights.shape[1]
     k = weights.shape[2]
-    for node1 in x:
+
+    for n1_pos, node1 in enumerate(x):
         f1 = node1[0]
         j1 = node1[1]
         v1 = node1[2]
         if j1 >= n or f1 >= m:
             continue
 
-        assert len(x) > 2, "it must contain two or more ffm_nodes"
-        for node2 in x[1:]:
+        for node2 in x[n1_pos+1:]:
             f2 = node2[0]
             j2 = node2[1]
             v2 = node2[2]

--- a/regression_test.sh
+++ b/regression_test.sh
@@ -9,14 +9,14 @@ set -ex
 
 python setup.py develop
 
-./ffm-train -p ./bigdata.te.txt -W ./bigdata.iw.txt -f ./model/dummy-1.model -m key --auto-stop --auto-stop-threshold 3 ./bigdata.tr.txt
-pyffm-train -p ./bigdata.te.txt -W ./bigdata.iw.txt -f ./model/dummy-2.model -m key --auto-stop --auto-stop-threshold 3 ./bigdata.tr.txt
+./ffm-train -p ./bigdata.te.txt -W ./bigdata.iw.txt --auto-stop --auto-stop-threshold 3 ./bigdata.tr.txt ./model/dummy-1.model
+pyffm-train -p ./bigdata.te.txt -W ./bigdata.iw.txt --auto-stop --auto-stop-threshold 3 ./bigdata.tr.txt ./model/dummy-2.model
 
 diff ./model/dummy-1.model ./model/dummy-2.model
 
-./ffm-train -p ./bigdata.te.txt -W ./bigdata.iw.txt --auto-stop --auto-stop-threshold 3 ./bigdata.tr.txt ./model/dummy-3.model
-pyffm-train -p ./bigdata.te.txt -W ./bigdata.iw.txt --auto-stop --auto-stop-threshold 3 ./bigdata.tr.txt ./model/dummy-4.model
+./ffm-predict ./bigdata.te.txt ./model/dummy-1.model ./model/predicted-1.txt
+pyffm-predict ./bigdata.te.txt ./model/dummy-2.model ./model/predicted-2.txt
 
-diff ./model/dummy-3.model ./model/dummy-4.model
+diff ./model/predicted-1.txt ./model/predicted-2.txt
 
 echo "ok"

--- a/regression_test.sh
+++ b/regression_test.sh
@@ -7,6 +7,8 @@ rm ./model/*.model
 
 set -ex
 
+make clean
+make USEOMP=OFF
 python setup.py develop
 
 ./ffm-train -p ./bigdata.te.txt -W ./bigdata.iw.txt --auto-stop --auto-stop-threshold 3 ./bigdata.tr.txt ./model/dummy-1.model

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
     entry_points={
         "console_scripts": [
             "pyffm-train = ffm.cli:ffm_train",
+            "pyffm-predict = ffm.cli:ffm_predict",
         ],
     },
     include_package_data=False,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,44 +1,92 @@
 import pytest
 from io import StringIO
-from ffm import read_importance_weights, read_ffm_data
+from ffm import read_importance_weights, read_ffm_data, read_ffm_model
 
 
 def test_read_importance_weights() -> None:
-    data = StringIO("""0.9
+    data = StringIO(
+        """0.9
 0.3
 0.5
-""")
+"""
+    )
     expected = [0.9, 0.3, 0.5]
     actual = read_importance_weights(data)
     assert pytest.approx(actual) == expected
 
 
 def test_read_weights_contains_negative() -> None:
-    data = StringIO("""0.9
+    data = StringIO(
+        """0.9
 -0.1
 0.3
-""")
+"""
+    )
     with pytest.raises(AssertionError):
         read_importance_weights(data)
 
 
 def test_read_ffm_data() -> None:
-    data = StringIO("""
+    data = StringIO(
+        """
 0 1:7985267:1 2:2281974:1 3:4974058:1 4:3977160:1
 1 1:7985267:1 2:2281974:1 3:4974058:1 4:9538220:1
-""")
+"""
+    )
     actual_data, actual_target = read_ffm_data(data)
 
     assert len(actual_data) == 2
-    assert pytest.approx(actual_data[0]) == [(1, 7985267, 1), (2, 2281974, 1), (3, 4974058, 1), (4, 3977160, 1)]
-    assert pytest.approx(actual_data[1]) == [(1, 7985267, 1), (2, 2281974, 1), (3, 4974058, 1), (4, 9538220, 1)]
+    assert pytest.approx(actual_data[0]) == [
+        (1, 7985267, 1),
+        (2, 2281974, 1),
+        (3, 4974058, 1),
+        (4, 3977160, 1),
+    ]
+    assert pytest.approx(actual_data[1]) == [
+        (1, 7985267, 1),
+        (2, 2281974, 1),
+        (3, 4974058, 1),
+        (4, 9538220, 1),
+    ]
 
     assert pytest.approx(actual_target) == [0, 1]
 
 
 def test_read_ffm_data_contains_negative_feature_idx() -> None:
-    data = StringIO("""
+    data = StringIO(
+        """
 0 1:-1:1 2:2281974:1 3:4974058:1 4:3977160:1
-""")
+"""
+    )
     with pytest.raises(AssertionError):
         read_ffm_data(data)
+
+
+def test_read_ffm_model() -> None:
+    data = StringIO(
+        """n 9991
+m 18
+k 4
+normalization 1
+w0,0 1.12387e-05 0.0425162 0.300676 0.445806 
+w0,1 0.483978 0.0948449 0.257488 0.199004 
+w0,2 0.16383 0.413805 0.0657625 0.310082 
+w0,3 0.308203 0.427194 0.309345 0.277694 
+"""
+    )
+    model = read_ffm_model(data)
+    assert model.weights.shape == (9991, 18, 4)
+    assert model.normalization
+
+    assert model.weights[0, 0] == pytest.approx(
+        [1.12387e-05, 0.0425162, 0.300676, 0.445806]
+    )
+    assert model.weights[0, 1] == pytest.approx(
+        [0.483978, 0.0948449, 0.257488, 0.199004]
+    )
+    assert model.weights[0, 2] == pytest.approx(
+        [0.16383, 0.413805, 0.0657625, 0.310082]
+    )
+    assert model.weights[0, 3] == pytest.approx(
+        [0.308203, 0.427194, 0.309345, 0.277694]
+    )


### PR DESCRIPTION
I confirmed that:

* There are no differences in prediction results between `ffm-predict` command (provided by LIBFFM) and `pyffm-predict` command (See the [benchmark script](https://gist.github.com/c-bata/1f2d6078c432b286a6c97674d916f81f) for details).
* `Model.predict()` method runs faster than calling LIBFFM's CLI via subprocess.

Usage of Python interface is:

```python
import ffm

def predict():
    model = ffm.Model.read_ffm_model("./dummy.model")
    dataset = ffm.Dataset.read_ffm_data("./bigdata.te.txt")

    preds = []
    for x in dataset.data:
        pred_y = model.predict(x)
        preds.append(pred_y)
    print(preds)
```

Usage of command line interface is:

```
$ pyffm-predict ./bigdata.te.txt ./model/dummy.model ./model/predicted.txt
```

Note that this is equivalent with the following command.

```
$ ./ffm-predict ./bigdata.te.txt ./model/dummy.model ./model/predicted.txt
```