### PR TITLE
Feature: Add data path to train method

### DIFF
--- a/ffm/__init__.py
+++ b/ffm/__init__.py
@@ -93,8 +93,10 @@ class Model:
 
 
 def train(
-    train_data: Dataset,
+    train_data: Optional[Dataset] = None,
+    train_path: str = None,
     valid_data: Optional[Dataset] = None,
+    valid_path: str = None,
     eta: float = 0.2,
     lam: float = 0.00002,
     nr_iters: int = 15,
@@ -107,8 +109,10 @@ def train(
     random: bool = True,
     nds_rate: float = 1.0,
 ) -> Model:
-    tr = (train_data.data, train_data.labels)
-    iw = train_data.importance_weights
+    tr, iw = None, None
+    if train_data is not None:
+        tr = (train_data.data, train_data.labels)
+        iw = train_data.importance_weights
 
     va, iwv = None, None
     if valid_data is not None:
@@ -116,8 +120,10 @@ def train(
         iwv = valid_data.importance_weights
 
     weights, best_iteration, normalization, best_va_loss = libffm_train(
-        tr,
+        tr=tr,
+        tr_path=train_path,
         va=va,
+        va_path=valid_path,
         iw=iw,
         iwv=iwv,
         eta=eta,

--- a/ffm/__init__.py
+++ b/ffm/__init__.py
@@ -94,9 +94,9 @@ class Model:
 
 def train(
     train_data: Optional[Dataset] = None,
-    train_path: str = None,
+    train_path: Optional[str] = None,
     valid_data: Optional[Dataset] = None,
-    valid_path: str = None,
+    valid_path: Optional[str] = None,
     eta: float = 0.2,
     lam: float = 0.00002,
     nr_iters: int = 15,

--- a/ffm/libffm.pyx
+++ b/ffm/libffm.pyx
@@ -56,6 +56,7 @@ cdef extern from "ffm.h" namespace "ffm" nogil:
         ffm_float best_va_loss
 
     ffm_model *ffm_train_with_validation(ffm_problem *Tr, ffm_problem *Va, ffm_importance_weights *iws, ffm_importance_weights *iwvs, ffm_parameter param);
+    ffm_problem *ffm_read_problem(char *path);
 
 
 cdef ffm_problem* make_ffm_prob(X, y):
@@ -174,8 +175,10 @@ cdef object _train(
 
 
 def train(
-    tr,
+    tr=None,
+    tr_path=None,
     va=None,
+    va_path=None,
     iw=None,
     iwv=None,
     eta=0.2,
@@ -205,11 +208,18 @@ def train(
     param.nds_rate = nds_rate
 
     cdef:
-        ffm_problem* tr_ptr = make_ffm_prob(tr[0], tr[1])
+        ffm_problem* tr_ptr
         ffm_problem* va_ptr
         ffm_importance_weights *iw_ptr, *iwv_ptr
 
-    if va is not None:
+    if tr_path is not None:
+        tr_ptr = ffm_read_problem(tr_path.encode("utf-8"))
+    else:
+        tr_ptr = make_ffm_prob(tr[0], tr[1])
+
+    if va_path is not None:
+        va_ptr = ffm_read_problem(va_path.encode("utf-8"))
+    elif va is not None:
         va_ptr = make_ffm_prob(va[0], va[1])
     else:
         va_ptr = NULL

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ if cythonize is not None:
 
 setup(
     name="ffm",
-    version="0.3.1",
+    version="0.4.0",
     description="LibFFM Python Package",
     long_description="LibFFM Python Package",
     install_requires=["numpy"],


### PR DESCRIPTION
The details is described in https://www.notion.so/cyberagentai/libFFM-bde75aec6cdc4619b096227cd2493d48
I added the implementation to load the dataset in c function.

## Train method change
Before
```python
train_data = ffm.Dataset.read_ffm_data("train_path.txt")
valid_data = ffm.Dataset.read_ffm_data("valid_path.txt")
ffm.train(train_data=train_data, valid_path=valid_data)
```

After
```python
train_path = "train_path.txt"
valid_path = "valid_path.txt"
ffm.train(train_path=train_path, valid_path=valid_path)
```

If you passed both train_path and train_data arguments, train_path take priority.
```python
train_path = "train_path.txt"
train_data = ffm.Dataset.read_ffm_data("train_path.txt")
ffm.train(train_data=train_data, train_path=train_path)
```