### PR TITLE
Fix build files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy", "Cython"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,28 +1,28 @@
 import os
-
-import numpy
 from setuptools import Extension, find_packages, setup
 
-try:
-    from Cython.Build import cythonize
 
-    ext = ".pyx"
-except ImportError:
-    cythonize = None
-    ext = ".cpp"
+def make_extensions():
+    import numpy
+    try:
+        from Cython.Build import cythonize
+        ext = ".pyx"
+    except ImportError:
+        cythonize = None
+        ext = ".cpp"
+    ext_modules = [
+        Extension(
+            "ffm.libffm",
+            extra_compile_args=["-Wall", "-O3", "-std=c++0x", "-march=native", "-DUSESSE"],
+            sources=[os.path.join("ffm", "libffm" + ext), "ffm.cpp"],
+            include_dirs=[".", numpy.get_include()],
+            language="c++",
+        )
+    ]
+    if cythonize is not None:
+        ext_modules = cythonize(ext_modules)
+    return ext_modules
 
-ext_modules = [
-    Extension(
-        "ffm.libffm",
-        extra_compile_args=["-Wall", "-O3", "-std=c++0x", "-march=native", "-DUSESSE"],
-        sources=[os.path.join("ffm", "libffm" + ext), "ffm.cpp"],
-        include_dirs=[".", numpy.get_include()],
-        language="c++",
-    )
-]
-
-if cythonize is not None:
-    ext_modules = cythonize(ext_modules)
 
 setup(
     name="ffm",
@@ -30,7 +30,7 @@ setup(
     description="LibFFM Python Package",
     long_description="LibFFM Python Package",
     install_requires=["numpy"],
-    ext_modules=ext_modules,
+    ext_modules=make_extensions(),
     maintainer="",
     maintainer_email="",
     zip_safe=False,


### PR DESCRIPTION
## 概要
build時にnumpyの依存関係の順序が担保されない(pipだから)ので、これらの依存関係を担保する様にスクリプト書き換えました。

```
"/var/folders/ht/41q54f8x0k3_c3sqy9qkrmhw38h6wm/T/tmpjg28t2n6/.venv/lib/python3.8/site-packages/setuptools/build_meta.py", line 338, in run_setup
      exec(code, locals())
    File "<string>", line 3, in <module>
  ModuleNotFoundError: No module named 'numpy'
```